### PR TITLE
Added support for showing Team Name and the Fundraising Goal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,18 @@
-import React from "react";
 import "./App.css";
 import Logo from "./components/Logo";
 import Progress from "./components/Progress";
-import { getQueryStringValue, checkQueryStringBoolean, prepareClassString } from "./utils";
+import {
+  getQueryStringValue,
+  checkQueryStringBoolean,
+  prepareClassString,
+} from "./utils";
 import { Orientation } from "./models/Orientation";
 
 const App: React.FC = (props) => {
   const orientation = getQueryStringValue("orientation");
   const debuggingMode = checkQueryStringBoolean("debugging");
+  const showTeamName = checkQueryStringBoolean("showTeamName");
+  const showGoal = checkQueryStringBoolean("showGoal");
   const topLevelClasses = prepareClassString(
     "app",
     orientation || Orientation.Left,
@@ -17,7 +22,13 @@ const App: React.FC = (props) => {
   return (
     <div className={topLevelClasses} data-testid="app">
       <Logo />
-      <Progress className={orientation || Orientation.Left} />
+      <Progress
+        className={orientation || Orientation.Left}
+        options={{
+          showTeamName,
+          showGoal,
+        }}
+      />
     </div>
   );
 };

--- a/src/components/Progress.css
+++ b/src/components/Progress.css
@@ -1,8 +1,18 @@
+.progress-region {
+  display: grid;
+  grid-template-columns: auto;
+  grid-template-rows: 1fr 1fr 1fr;
+  height: 120px;
+}
+
 .progress-container {
   position: relative;
   display: flex;
   flex-direction: row;
   align-items: center;
+  place-self: center;
+  grid-column: 1;
+  grid-row: 2/3;
 }
 
 .progress-container.right {
@@ -62,6 +72,38 @@
 }
 
 .progress-text.right {
+  direction: rtl;
+}
+
+.progress-team-name {
+  color: white;
+  font-size: 1.5rem;
+  align-self: end;
+  grid-column: 1;
+  grid-row: 1/2;
+}
+
+.progress-team-name p {
+  margin: 0;
+}
+
+.progress-team-name.right {
+  direction: rtl;
+}
+
+.progress-goal {
+  color: white;
+  font-size: 1.25rem;
+  align-self: start;
+  grid-column: 1;
+  grid-row: 3;
+}
+
+.progress-goal p {
+  margin: 0;
+}
+
+.progress-goal.right {
   direction: rtl;
 }
 

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -2,8 +2,6 @@ import { connect } from "react-redux";
 import { useSpring, animated } from "react-spring";
 import "./Progress.css";
 import { IAppState } from "../models/IAppState";
-import { IParticipant } from "../models/IParticipant";
-import { ITeam } from "../models/ITeam";
 
 export interface IProgressOptions {
   showTeamName: boolean;

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -1,18 +1,32 @@
-import React from "react";
 import { connect } from "react-redux";
 import { useSpring, animated } from "react-spring";
 import "./Progress.css";
 import { IAppState } from "../models/IAppState";
+import { IParticipant } from "../models/IParticipant";
+import { ITeam } from "../models/ITeam";
+
+export interface IProgressOptions {
+  showTeamName: boolean;
+  showGoal: boolean;
+}
 
 export interface IProgressOwnProps {
   className?: string;
+  options?: IProgressOptions;
 }
 
 export interface IProgressProps {
   className?: string;
   sumDonations: number;
   fundraisingGoal: number;
+  teamName?: string;
+  showGoal: boolean;
 }
+
+const createDefaultOptions = (): IProgressOptions => ({
+  showTeamName: false,
+  showGoal: false,
+});
 
 const clamp = (value: number, min: number, max: number) => {
   if (value > min && value < max) return value;
@@ -24,7 +38,13 @@ const calculateCompletedWidth = (current: number, goal: number) =>
   clamp((current / goal) * 100, 0, 100);
 
 const Progress: React.FC<IProgressProps> = (props) => {
-  const { className: classes, sumDonations, fundraisingGoal } = props;
+  const {
+    className: classes,
+    sumDonations,
+    fundraisingGoal,
+    teamName,
+    showGoal,
+  } = props;
 
   const hasValues = fundraisingGoal !== 0 && sumDonations >= 0;
 
@@ -37,13 +57,28 @@ const Progress: React.FC<IProgressProps> = (props) => {
   if (!hasValues) return null;
 
   return (
-    <div className="progress-container" data-testid="progress">
-      <div className={"progress-bar " + classes}>
-        <animated.div className="completed" style={springWidth}></animated.div>
+    <div className={"progress-region"}>
+      {teamName && (
+        <div className={"progress-team-name " + classes}>
+          <p>{teamName}</p>
+        </div>
+      )}
+      <div className="progress-container" data-testid="progress">
+        <div className={"progress-bar " + classes}>
+          <animated.div
+            className="completed"
+            style={springWidth}
+          ></animated.div>
+        </div>
+        <div className={"progress-text " + classes}>
+          <p>${sumDonations.toFixed(2)}</p>
+        </div>
       </div>
-      <div className={"progress-text " + classes}>
-        <p>${sumDonations.toFixed(2)}</p>
-      </div>
+      {showGoal && (
+        <div className={"progress-goal " + classes}>
+          <p>${fundraisingGoal.toFixed(2)}</p>
+        </div>
+      )}
     </div>
   );
 };
@@ -53,7 +88,7 @@ const mapStateToProps = (state: IAppState, ownProps: IProgressOwnProps) => {
     participant: { value: participant },
     team: { value: team },
   } = state;
-  const { className } = ownProps;
+  const { className, options } = ownProps;
 
   const sumDonations = participant
     ? participant.sumDonations
@@ -66,10 +101,14 @@ const mapStateToProps = (state: IAppState, ownProps: IProgressOwnProps) => {
     ? team.fundraisingGoal
     : 0;
 
+  const safeOptions = options || createDefaultOptions();
+
   return {
     className,
     sumDonations,
     fundraisingGoal,
+    teamName: safeOptions.showTeamName ? team?.name : undefined,
+    showGoal: safeOptions.showGoal,
   };
 };
 


### PR DESCRIPTION
Partially resolves #13. Milestones will take a bit more work and will be in a separate PR.

This PR adds two new URL parameters:

- `showTeamName` which accepts a `true` or `false` value and will show the team name in the event that `team` is also set.
- `showGoal` which accepts a `true` or `false` value and will show the fundraising goal. If `team` is set, it will show the `team` goal. Otherwise it show's the goal for the `participant`.