### PR TITLE
Added initial support for fetching milestones for participants

### DIFF
--- a/src/models/IAppState.ts
+++ b/src/models/IAppState.ts
@@ -5,6 +5,7 @@ export interface IParticipantState {
   isFetchingParticipant: boolean;
   id?: ParticipantId;
   value?: IParticipant;
+  fetchMilestones: boolean;
 }
 
 export interface ITeamState {

--- a/src/models/IParticipant.ts
+++ b/src/models/IParticipant.ts
@@ -1,5 +1,13 @@
 export type ParticipantId = number;
 
+export interface IParticipantMilestone {
+  fundraisingGoal: number;
+  description: string;
+  milestoneId: string;
+  isActive: boolean;
+  isComplete: boolean;
+}
+
 export interface IParticipantLinks {
   donate: string;
   stream: string;
@@ -19,4 +27,5 @@ export interface IParticipant {
   sumDonations: number;
   sumPledges: number;
   numDonations: number;
+  milestones: IParticipantMilestone[];
 }

--- a/src/services/ExtraLife.ts
+++ b/src/services/ExtraLife.ts
@@ -1,7 +1,11 @@
-import { IParticipant, ParticipantId } from "../models/IParticipant";
+import {
+  IParticipant,
+  IParticipantMilestone,
+  ParticipantId,
+} from "../models/IParticipant";
 import { ITeam, TeamId } from "../models/ITeam";
 
-const API_HOST = 'www.extra-life.org'
+const API_HOST = "www.extra-life.org";
 
 export function fetchParticipantById(
   participantId: ParticipantId
@@ -13,12 +17,20 @@ export function fetchParticipantById(
     );
 }
 
-export function fetchTeamById(
-  teamId: TeamId
-): Promise<ITeam> {
-  return fetch(`https://${API_HOST}/api/teams/${teamId}`)
+export function fetchParticipantMilestonesById(
+  participantId: ParticipantId
+): Promise<IParticipantMilestone[]> {
+  return fetch(
+    `https://${API_HOST}/api/participants/${participantId}/milestones`
+  )
     .then((r) => r.json())
     .catch((e) =>
-      console.error(`Fetch team by id failed. Reason: ${e}`)
+      console.error(`Fetch participant milestones by id failed. Reason: ${e}`)
     );
+}
+
+export function fetchTeamById(teamId: TeamId): Promise<ITeam> {
+  return fetch(`https://${API_HOST}/api/teams/${teamId}`)
+    .then((r) => r.json())
+    .catch((e) => console.error(`Fetch team by id failed. Reason: ${e}`));
 }

--- a/src/store/Sagas.ts
+++ b/src/store/Sagas.ts
@@ -2,15 +2,18 @@ import { fork, put } from "redux-saga/effects";
 import { runParticipantSagas } from "./participant/Sagas";
 import * as participantActions from "./participant/Actions";
 import * as teamActions from "./team/Actions";
-import { getQueryStringValue } from "../utils";
+import { checkQueryStringBoolean, getQueryStringValue } from "../utils";
 import { runTeamSagas } from "./team/Sagas";
 
 export function* startup() {
   const participantId = getQueryStringValue("participant");
+  const fetchMilestones = checkQueryStringBoolean("milestones");
 
   if (participantId) {
     yield fork(runParticipantSagas);
-    yield put(participantActions.setParticipantId(+participantId));
+    yield put(
+      participantActions.setParticipantId(+participantId, fetchMilestones)
+    );
   } else {
     const teamId = getQueryStringValue("team");
     if (teamId) {

--- a/src/store/participant/Actions.ts
+++ b/src/store/participant/Actions.ts
@@ -7,19 +7,25 @@ import {
 import { ParticipantActionTypes } from "./Types";
 import { ParticipantId, IParticipant } from "../../models/IParticipant";
 
-export function setParticipantId(id: ParticipantId): ISetParticipantIdAction {
+export function setParticipantId(
+  id: ParticipantId,
+  fetchMilestones: boolean
+): ISetParticipantIdAction {
   return {
     type: ParticipantActionTypes.PARTICIPANT_ID_SET,
     id,
+    fetchMilestones,
   };
 }
 
 export function requestParticipantFetch(
-  id: ParticipantId
+  id: ParticipantId,
+  fetchMilestones: boolean
 ): IRequestParticipantFetchAction {
   return {
     type: ParticipantActionTypes.PARTICIPANT_FETCH_REQUESTED,
     id,
+    fetchMilestones,
   };
 }
 

--- a/src/store/participant/Interfaces.ts
+++ b/src/store/participant/Interfaces.ts
@@ -10,11 +10,13 @@ export type ParticipantActions =
 export interface ISetParticipantIdAction {
   readonly type: ParticipantActionTypes.PARTICIPANT_ID_SET;
   readonly id: ParticipantId;
+  readonly fetchMilestones: boolean;
 }
 
 export interface IRequestParticipantFetchAction {
   readonly type: ParticipantActionTypes.PARTICIPANT_FETCH_REQUESTED;
   readonly id: ParticipantId;
+  readonly fetchMilestones: boolean;
 }
 
 export interface ISuccessfulParticipantFetchAction {

--- a/src/store/participant/Reducers.ts
+++ b/src/store/participant/Reducers.ts
@@ -5,6 +5,7 @@ import { ParticipantActionTypes } from "./Types";
 export function participant(
   state: IParticipantState = {
     isFetchingParticipant: false,
+    fetchMilestones: false,
   },
   action: ParticipantActions
 ) {
@@ -13,6 +14,7 @@ export function participant(
       return {
         ...state,
         id: action.id,
+        fetchMilestones: action.fetchMilestones,
       };
     case ParticipantActionTypes.PARTICIPANT_FETCH_REQUESTED:
       return {

--- a/src/store/participant/Selectors.ts
+++ b/src/store/participant/Selectors.ts
@@ -2,5 +2,8 @@ import { IAppState } from "../../models/IAppState";
 
 export const getParticipantId = (state: IAppState) => state.participant.id;
 
+export const getFetchMilestones = (state: IAppState) =>
+  state.participant.fetchMilestones;
+
 export const isParticipantRequestInFlight = (state: IAppState) =>
   state.participant.isFetchingParticipant;


### PR DESCRIPTION
Resolves #13, with caveat below. Opened #21 to track additional future work.

This PR adds support for fetching and displaying milestones in the **left orientation only**. Support for milestones in the right orientation is on the roadmap for a future release post-2021 Extra Life Game Day. At this time support for right milestones will take significant work I don´t have time for at the moment. This additional work is tracked in issue #21.

**Milestones only work with participants.** Unfortunately the Donor Drive API does not support milestones for Teams.

To use milestones, add `milestones=true` to your URL parameter.

An example URL: `https://weegeekps.github.io/extra-life-overlay/?participant=468964&milestones=true`

Should show something like this:

![Screenshot_20211031_180636](https://user-images.githubusercontent.com/284269/139604793-f7c47e3d-2863-4e16-9aab-a80a56628b62.png)


