### PR TITLE
Add initial support for participant milestones

### DIFF
--- a/src/components/Progress.css
+++ b/src/components/Progress.css
@@ -75,6 +75,26 @@
   direction: rtl;
 }
 
+.progress-milestone {
+  position: absolute;
+  z-index: 1;
+  display: flex;
+  justify-content: flex-end;
+  height: 100%;
+}
+
+.progress-milestone.left {
+  margin-left: -3rem;
+}
+
+.progress-milestone-indicator {
+  width: 3px;
+  height: 40px;
+  background-color: #c73047;
+  border-bottom: solid 4px white;
+  border-top: solid 4px white;
+}
+
 .progress-team-name {
   color: white;
   font-size: 1.5rem;

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -2,6 +2,8 @@ import { connect } from "react-redux";
 import { useSpring, animated } from "react-spring";
 import "./Progress.css";
 import { IAppState } from "../models/IAppState";
+import { IParticipantMilestone } from "../models/IParticipant";
+import { clamp } from "../utils";
 
 export interface IProgressOptions {
   showTeamName: boolean;
@@ -19,18 +21,13 @@ export interface IProgressProps {
   fundraisingGoal: number;
   teamName?: string;
   showGoal: boolean;
+  milestones: IParticipantMilestone[];
 }
 
 const createDefaultOptions = (): IProgressOptions => ({
   showTeamName: false,
   showGoal: false,
 });
-
-const clamp = (value: number, min: number, max: number) => {
-  if (value > min && value < max) return value;
-  if (value < min) return min;
-  if (value > max) return max;
-};
 
 const calculateCompletedWidth = (current: number, goal: number) =>
   clamp((current / goal) * 100, 0, 100);
@@ -42,6 +39,7 @@ const Progress: React.FC<IProgressProps> = (props) => {
     fundraisingGoal,
     teamName,
     showGoal,
+    milestones,
   } = props;
 
   const hasValues = fundraisingGoal !== 0 && sumDonations >= 0;
@@ -71,6 +69,15 @@ const Progress: React.FC<IProgressProps> = (props) => {
         <div className={"progress-text " + classes}>
           <p>${sumDonations.toFixed(2)}</p>
         </div>
+        {milestones.map((milestone) => (
+          <div
+            className={"progress-milestone " + classes}
+            style={{ width: milestone.position + "%" }}
+            key={milestone.milestoneId}
+          >
+            <div className="progress-milestone-indicator"></div>
+          </div>
+        ))}
       </div>
       {showGoal && (
         <div className={"progress-goal " + classes}>
@@ -101,12 +108,15 @@ const mapStateToProps = (state: IAppState, ownProps: IProgressOwnProps) => {
 
   const safeOptions = options || createDefaultOptions();
 
+  const milestones = participant ? participant.milestones : [];
+
   return {
     className,
     sumDonations,
     fundraisingGoal,
     teamName: safeOptions.showTeamName ? team?.name : undefined,
     showGoal: safeOptions.showGoal,
+    milestones,
   };
 };
 

--- a/src/models/IAppState.ts
+++ b/src/models/IAppState.ts
@@ -5,6 +5,7 @@ export interface IParticipantState {
   isFetchingParticipant: boolean;
   id?: ParticipantId;
   value?: IParticipant;
+  fetchMilestones: boolean;
 }
 
 export interface ITeamState {

--- a/src/models/IParticipant.ts
+++ b/src/models/IParticipant.ts
@@ -1,5 +1,13 @@
 export type ParticipantId = number;
 
+export interface IParticipantMilestone {
+  fundraisingGoal: number;
+  description: string;
+  milestoneId: string;
+  isActive: boolean;
+  isComplete: boolean;
+}
+
 export interface IParticipantLinks {
   donate: string;
   stream: string;
@@ -19,4 +27,5 @@ export interface IParticipant {
   sumDonations: number;
   sumPledges: number;
   numDonations: number;
+  milestones: IParticipantMilestone[];
 }

--- a/src/models/IParticipant.ts
+++ b/src/models/IParticipant.ts
@@ -6,6 +6,7 @@ export interface IParticipantMilestone {
   milestoneId: string;
   isActive: boolean;
   isComplete: boolean;
+  position?: number; // This is a number calculated after we fetch the milestones.
 }
 
 export interface IParticipantLinks {

--- a/src/services/ExtraLife.ts
+++ b/src/services/ExtraLife.ts
@@ -1,7 +1,11 @@
-import { IParticipant, ParticipantId } from "../models/IParticipant";
+import {
+  IParticipant,
+  IParticipantMilestone,
+  ParticipantId,
+} from "../models/IParticipant";
 import { ITeam, TeamId } from "../models/ITeam";
 
-const API_HOST = 'www.extra-life.org'
+const API_HOST = "www.extra-life.org";
 
 export function fetchParticipantById(
   participantId: ParticipantId
@@ -13,12 +17,20 @@ export function fetchParticipantById(
     );
 }
 
-export function fetchTeamById(
-  teamId: TeamId
-): Promise<ITeam> {
-  return fetch(`https://${API_HOST}/api/teams/${teamId}`)
+export function fetchParticipantMilestonesById(
+  participantId: ParticipantId
+): Promise<IParticipantMilestone[]> {
+  return fetch(
+    `https://${API_HOST}/api/participants/${participantId}/milestones`
+  )
     .then((r) => r.json())
     .catch((e) =>
-      console.error(`Fetch team by id failed. Reason: ${e}`)
+      console.error(`Fetch participant milestones by id failed. Reason: ${e}`)
     );
+}
+
+export function fetchTeamById(teamId: TeamId): Promise<ITeam> {
+  return fetch(`https://${API_HOST}/api/teams/${teamId}`)
+    .then((r) => r.json())
+    .catch((e) => console.error(`Fetch team by id failed. Reason: ${e}`));
 }

--- a/src/store/Sagas.ts
+++ b/src/store/Sagas.ts
@@ -2,15 +2,18 @@ import { fork, put } from "redux-saga/effects";
 import { runParticipantSagas } from "./participant/Sagas";
 import * as participantActions from "./participant/Actions";
 import * as teamActions from "./team/Actions";
-import { getQueryStringValue } from "../utils";
+import { checkQueryStringBoolean, getQueryStringValue } from "../utils";
 import { runTeamSagas } from "./team/Sagas";
 
 export function* startup() {
   const participantId = getQueryStringValue("participant");
+  const fetchMilestones = checkQueryStringBoolean("milestones");
 
   if (participantId) {
     yield fork(runParticipantSagas);
-    yield put(participantActions.setParticipantId(+participantId));
+    yield put(
+      participantActions.setParticipantId(+participantId, fetchMilestones)
+    );
   } else {
     const teamId = getQueryStringValue("team");
     if (teamId) {

--- a/src/store/Sagas.ts
+++ b/src/store/Sagas.ts
@@ -7,7 +7,10 @@ import { runTeamSagas } from "./team/Sagas";
 
 export function* startup() {
   const participantId = getQueryStringValue("participant");
-  const fetchMilestones = checkQueryStringBoolean("milestones");
+  const orientation = getQueryStringValue("orientation");
+  // Implementing milestones for right orientation is going to take a massive amount of work,
+  //  so if orientation is set, we just won't fetch milestones for now.
+  const fetchMilestones = !orientation && checkQueryStringBoolean("milestones");
 
   if (participantId) {
     yield fork(runParticipantSagas);

--- a/src/store/participant/Actions.ts
+++ b/src/store/participant/Actions.ts
@@ -7,19 +7,25 @@ import {
 import { ParticipantActionTypes } from "./Types";
 import { ParticipantId, IParticipant } from "../../models/IParticipant";
 
-export function setParticipantId(id: ParticipantId): ISetParticipantIdAction {
+export function setParticipantId(
+  id: ParticipantId,
+  fetchMilestones: boolean
+): ISetParticipantIdAction {
   return {
     type: ParticipantActionTypes.PARTICIPANT_ID_SET,
     id,
+    fetchMilestones,
   };
 }
 
 export function requestParticipantFetch(
-  id: ParticipantId
+  id: ParticipantId,
+  fetchMilestones: boolean
 ): IRequestParticipantFetchAction {
   return {
     type: ParticipantActionTypes.PARTICIPANT_FETCH_REQUESTED,
     id,
+    fetchMilestones,
   };
 }
 

--- a/src/store/participant/Interfaces.ts
+++ b/src/store/participant/Interfaces.ts
@@ -10,11 +10,13 @@ export type ParticipantActions =
 export interface ISetParticipantIdAction {
   readonly type: ParticipantActionTypes.PARTICIPANT_ID_SET;
   readonly id: ParticipantId;
+  readonly fetchMilestones: boolean;
 }
 
 export interface IRequestParticipantFetchAction {
   readonly type: ParticipantActionTypes.PARTICIPANT_FETCH_REQUESTED;
   readonly id: ParticipantId;
+  readonly fetchMilestones: boolean;
 }
 
 export interface ISuccessfulParticipantFetchAction {

--- a/src/store/participant/Reducers.ts
+++ b/src/store/participant/Reducers.ts
@@ -5,6 +5,7 @@ import { ParticipantActionTypes } from "./Types";
 export function participant(
   state: IParticipantState = {
     isFetchingParticipant: false,
+    fetchMilestones: false,
   },
   action: ParticipantActions
 ) {
@@ -13,6 +14,7 @@ export function participant(
       return {
         ...state,
         id: action.id,
+        fetchMilestones: action.fetchMilestones,
       };
     case ParticipantActionTypes.PARTICIPANT_FETCH_REQUESTED:
       return {

--- a/src/store/participant/Sagas.ts
+++ b/src/store/participant/Sagas.ts
@@ -12,6 +12,7 @@ import {
   getParticipantId,
   isParticipantRequestInFlight,
 } from "./Selectors";
+import { clamp } from "../../utils";
 
 const DELAY_IN_SECONDS = 60;
 
@@ -26,6 +27,14 @@ export function* retrieveParticipant(action: IRequestParticipantFetchAction) {
         fetchParticipantMilestonesById,
         action.id
       );
+
+      participant.milestones.forEach((milestone) => {
+        milestone.position = clamp(
+          (milestone.fundraisingGoal / participant.fundraisingGoal) * 100,
+          0,
+          100
+        );
+      });
     } else {
       participant.milestones = [];
     }

--- a/src/store/participant/Selectors.ts
+++ b/src/store/participant/Selectors.ts
@@ -2,5 +2,8 @@ import { IAppState } from "../../models/IAppState";
 
 export const getParticipantId = (state: IAppState) => state.participant.id;
 
+export const getFetchMilestones = (state: IAppState) =>
+  state.participant.fetchMilestones;
+
 export const isParticipantRequestInFlight = (state: IAppState) =>
   state.participant.isFetchingParticipant;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,3 +29,9 @@ export const checkQueryStringBoolean = (queryString: string) => {
 export const prepareClassString = (...classes: string[]) => {
   return classes.reduce((acc, val) => (acc += " " + val));
 };
+
+export const clamp = (value: number, min: number, max: number) => {
+  if (value > min && value < max) return value;
+  if (value < min) return min;
+  if (value > max) return max;
+};


### PR DESCRIPTION
Resolves #13, with caveat below. Opened #21 to track additional future work.

This PR adds support for fetching and displaying milestones in the **left orientation only**. Support for milestones in the right orientation is on the roadmap for a future release post-2021 Extra Life Game Day. At this time support for right milestones will take significant work I don´t have time for at the moment. This additional work is tracked in issue #21.

**Milestones only work with participants.** Unfortunately the Donor Drive API does not support milestones for Teams.

To use milestones, add `milestones=true` to your URL parameter.

An example URL: `https://weegeekps.github.io/extra-life-overlay/?participant=468964&milestones=true`

Should show something like this:

![Screenshot_20211031_180636](https://user-images.githubusercontent.com/284269/139604793-f7c47e3d-2863-4e16-9aab-a80a56628b62.png)
